### PR TITLE
Calling the bootstrapper when Container is ready

### DIFF
--- a/Source/Bootstrap/AppExtensions.cs
+++ b/Source/Bootstrap/AppExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Builder
          /// <param name="app"><see cref="IApplicationBuilder"/> to use Dolittle for</param>
          public static void UseDolittle(this IApplicationBuilder app)
          {
+             Bootstrapper.Start(app.ApplicationServices.GetService(typeof(IContainer)) as IContainer);
              app.UseMiddleware<HealthCheckMiddleware>();
         }
 


### PR DESCRIPTION
Should be fixed by this: https://github.com/dolittle/DotNET.Fundamentals/issues/120