### PR TITLE
Fix request marshalling in CommandCoordinator

### DIFF
--- a/Source/Commands/CommandCoordinator.cs
+++ b/Source/Commands/CommandCoordinator.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
+using Dolittle.Artifacts;
 using Dolittle.Commands;
 using Dolittle.Commands.Coordination.Runtime;
 using Dolittle.Logging;
 using Microsoft.AspNetCore.Http;
+using SdkCommandRequest = Dolittle.Commands.CommandRequest;
 
 namespace Dolittle.AspNetCore.Commands
 {
@@ -38,10 +40,11 @@ namespace Dolittle.AspNetCore.Commands
         /// <returns>A task representing the asynchronous operation.</returns>
         public async Task Handle(HttpContext context)
         {
-            CommandRequest command = null;
+            SdkCommandRequest command = null;
             try
             {
-                command = await context.RequestBodyFromJson<CommandRequest>().ConfigureAwait(false);
+                var request = await context.RequestBodyFromJson<CommandRequest>().ConfigureAwait(false);
+                command = new SdkCommandRequest(request.CorrelationId, request.Type, ArtifactGeneration.First, request.Content);
                 var result = _commandCoordinator.Handle(command);
                 var status = result switch
                     {

--- a/Source/Commands/CommandRequest.cs
+++ b/Source/Commands/CommandRequest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Dolittle.Artifacts;
+using Dolittle.Execution;
+
+namespace Dolittle.AspNetCore.Commands
+{
+    /// <summary>
+    /// Represents a request for executing a command.
+    /// </summary>
+    public class CommandRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandRequest"/> class.
+        /// </summary>
+        /// <param name="correlationId">The <see cref="CorrelationId"/> representing the request.</param>
+        /// <param name="type">The <see cref="ArtifactId"/> representing the type of the Command.</param>
+        /// <param name="content">The content of the command.</param>
+        public CommandRequest(CorrelationId correlationId, ArtifactId type, IDictionary<string, object> content)
+        {
+            CorrelationId = correlationId;
+            Type = type;
+            Content = content;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="CorrelationId"/> representing the request.
+        /// </summary>
+        public CorrelationId CorrelationId { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ArtifactId"/> representing the type of the Command.
+        /// </summary>
+        public ArtifactId Type { get; }
+
+        /// <summary>
+        /// Gets the content of the command.
+        /// </summary>
+        public IDictionary<string, object> Content { get; }
+    }
+}

--- a/Source/Debugging/Debugging.csproj
+++ b/Source/Debugging/Debugging.csproj
@@ -14,9 +14,10 @@
     <PackageReference Include="Dolittle.SDK.Applications.Configuration" Version="$(SDKVersion)" />
     <PackageReference Include="Dolittle.SDK.Artifacts.Configuration" Version="$(SDKVersion)" />
     <PackageReference Include="Dolittle.SDK.Commands" Version="$(SDKVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwaggerVersion)" />
     <PackageReference Include="Dolittle.SDK.Commands.Coordination" Version="$(SDKVersion)" />    
     <PackageReference Include="Dolittle.SDK.Queries.Coordination" Version="$(SDKVersion)" />
     <PackageReference Include="Dolittle.SDK.Events" Version="$(SDKVersion)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwaggerVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/Source/Http/Http.csproj
+++ b/Source/Http/Http.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dolittle.Serialization.Json" Version="$(FundamentalsVersion)" />    
+    <PackageReference Include="Dolittle.Serialization.Json" Version="$(FundamentalsVersion)" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.1" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
The format of command requests from the frontend using the TypeScript CommandCoordinator does not match the format the SDK CommandCoordinator expects, which caused it to fail during deserialisation. Adding a class to use locally as a mid-point for properly deserialising command requests.

This sets the artifact generation of all commands to `1`, but since it is not sent from the frontend, that is currently the best we can do.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1171966200210885)
