### PR TITLE
Map dolittle application model endpoints

### DIFF
--- a/Samples/Debugging/Startup.cs
+++ b/Samples/Debugging/Startup.cs
@@ -43,8 +43,7 @@ namespace Debugging
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapDolittleCommandCoordinator();
-                endpoints.MapDolittleQueryCoordinator();
+                endpoints.MapDolittleApplicationModel();
                 endpoints.MapGet("/", context =>
                 {
                     context.Response.Redirect("/swagger");

--- a/Source/AggregatedPackage/EndpointRouteBuilderExtensions.cs
+++ b/Source/AggregatedPackage/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IEndpointRouteBuilder" />.
+    /// </summary>
+    public static class EndpointRouteBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a the Dolittle Application Model <see cref="RouteEndpoint">endpoints</see> to the <see cref="IEndpointRouteBuilder"/>.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static IEndpointRouteBuilder MapDolittleApplicationModel(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapDolittleCommandCoordinator();
+            endpoints.MapDolittleQueryCoordinator();
+            return endpoints;
+        }
+    }
+}

--- a/Source/AggregatedPackage/EndpointRouteBuilderExtensions.cs
+++ b/Source/AggregatedPackage/EndpointRouteBuilderExtensions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using Dolittle.Commands.Coordination;
+using Dolittle.Queries.Coordination;
 using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Builder
@@ -16,9 +19,23 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static IEndpointRouteBuilder MapDolittleApplicationModel(this IEndpointRouteBuilder endpoints)
+            => endpoints.MapDolittleApplicationModel(null, null);
+
+        /// <summary>
+        /// Adds a the Dolittle Application Model <see cref="RouteEndpoint">endpoints</see> to the <see cref="IEndpointRouteBuilder"/>.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="configureCommandCoordinator">An optional <see cref="Action{T}"/> of type <see cref="IEndpointConventionBuilder"/> that will be invoked to configure the <see cref="ICommandCoordinator"/> endpoint.</param>
+        /// <param name="configureQueryCoordinator">An optional <see cref="Action{T}"/> of type <see cref="IEndpointConventionBuilder"/> that will be invoked to configure the <see cref="IQueryCoordinator"/> endpoint.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static IEndpointRouteBuilder MapDolittleApplicationModel(this IEndpointRouteBuilder endpoints, Action<IEndpointConventionBuilder> configureCommandCoordinator = null, Action<IEndpointConventionBuilder> configureQueryCoordinator = null)
         {
-            endpoints.MapDolittleCommandCoordinator();
-            endpoints.MapDolittleQueryCoordinator();
+            var commandCoordinatorBuilder = endpoints.MapDolittleCommandCoordinator();
+            configureCommandCoordinator?.Invoke(commandCoordinatorBuilder);
+
+            var queryCoordinatorBuilder = endpoints.MapDolittleQueryCoordinator();
+            configureQueryCoordinator?.Invoke(queryCoordinatorBuilder);
+
             return endpoints;
         }
     }


### PR DESCRIPTION
Introduces a new extension method for IEndpointRouteBuilder that maps all the Dolittle Application Model endpoints with a single call. It takes optional configuration actions to configure the properties of the command and query coordinator endpoints.

Also changed the Debugging sample code to use this new extension method.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1176137432178856)
